### PR TITLE
[#63851, 63853, 63854] port deleteBackup, restoreBackup, and refreshBackupRestoreResult; bugfixes; port seeds

### DIFF
--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupExecutionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupExecutionProvider.groovy
@@ -219,7 +219,7 @@ class UpcloudBackupExecutionProvider implements BackupExecutionProvider {
 				}
 
 				rtn.success = true
-				rtn.data.backupResult.status = BackupStatusUtility.IN_PROGRESS
+				rtn.data.backupResult.status = BackupResult.Status.IN_PROGRESS
 				//rtn.data.backupResult.backupResultId = rtn.backupResultId
 				rtn.data.backupResult.sizeInMb = totalSize * 1024l
 				//rtn.data.backupResult.providerType = 'upcloud'
@@ -234,7 +234,7 @@ class UpcloudBackupExecutionProvider implements BackupExecutionProvider {
 				def errorMessage = errorSnapshots?.collect{ it.snapshotResult.msg }?.join('\n') ?: 'unknown error creating snapshots'
 				rtn.data.backupResult.sizeInMb = 0
 				rtn.data.backupResult.errorOutput = errorMessage
-				rtn.data.backupResult.status = BackupStatusUtility.FAILED
+				rtn.data.backupResult.status = BackupResult.Status.FAILED
 				rtn.data.updates = true
 			}
 			if(snapshotSuccess == true && opts.inline) {
@@ -249,7 +249,7 @@ class UpcloudBackupExecutionProvider implements BackupExecutionProvider {
 			rtn.msg = e.getMessage()
 			rtn.data.backupResult.errorOutput = "Failed to execute backup".encodeAsBase64()
 			rtn.data.backupResult.sizeInMb = 0
-			rtn.data.backupResult.status = BackupStatusUtility.FAILED
+			rtn.data.backupResult.status = BackupResult.Status.FAILED
 			rtn.data.updates = true
 		}
 		return rtn

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupRestoreProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupRestoreProvider.groovy
@@ -58,7 +58,7 @@ class UpcloudBackupRestoreProvider implements BackupRestoreProvider {
 	 */
 	@Override
 	ServiceResponse getBackupRestoreInstanceConfig(BackupResult backupResult, Instance instanceModel, Map restoreConfig, Map opts) {
-		return ServiceResponse.success()
+		return ServiceResponse.success(restoreConfig)
 	}
 
 	/**
@@ -139,13 +139,12 @@ class UpcloudBackupRestoreProvider implements BackupRestoreProvider {
 				def restoreSuccess = true
 				snapshotList?.each { snapshot ->
 					def restoreResult = UpcloudApiService.restoreSnapshot(authConfig, snapshot.storageId)
-					log.info("restore result data: ${restoreResult.data}")
 					restoreSuccess = restoreResult.success && restoreSuccess
 					restoreResults << restoreResult
 				}
 				log.info("restore results: {}", restoreResults)
 				if(restoreSuccess == true) {
-					rtn.data.backupRestore.status = BackupStatusUtility.IN_PROGRESS
+					rtn.data.backupRestore.status = BackupResult.Status.SUCCEEDED
 					rtn.data.backupRestore.externalId = server.externalId
 					rtn.data.backupRestore.startDate = new Date()
 					rtn.success = true
@@ -158,7 +157,7 @@ class UpcloudBackupRestoreProvider implements BackupRestoreProvider {
 					log.info("backup restore failed")
 					rtn.success = false
 					rtn.data.updates = true
-					rtn.data.backupRestore.status = BackupStatusUtility.FAILED
+					rtn.data.backupRestore.status = BackupResult.Status.FAILED
 				}
 			}
 		} catch(e) {
@@ -166,7 +165,7 @@ class UpcloudBackupRestoreProvider implements BackupRestoreProvider {
 			rtn.success = false
 			rtn.message = e.getMessage()
 			rtn.data.updates = true
-			rtn.data.backupRestore.status = BackupStatusUtility.FAILED
+			rtn.data.backupRestore.status = BackupResult.Status.FAILED
 			rtn.data.backupRestore.errorMessage = e.getMessage()
 		}
 		return rtn

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupTypeProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupTypeProvider.groovy
@@ -124,7 +124,7 @@ class UpcloudBackupTypeProvider extends AbstractBackupTypeProvider {
 	 */
 	@Override
 	String getRestoreNewMode() {
-		return "VM_RESTORE"
+		return null
 	}
 	
 	/**

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupTypeProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudBackupTypeProvider.groovy
@@ -152,7 +152,7 @@ class UpcloudBackupTypeProvider extends AbstractBackupTypeProvider {
 	@Override
 	UpcloudBackupExecutionProvider getExecutionProvider() {
 		if(!this.executionProvider) {
-			this.executionProvider = new UpcloudBackupExecutionProvider(getPlugin())
+			this.executionProvider = new UpcloudBackupExecutionProvider(getPlugin(), getMorpheus())
 		}
 		return this.executionProvider
 	}
@@ -164,7 +164,7 @@ class UpcloudBackupTypeProvider extends AbstractBackupTypeProvider {
 	@Override
 	UpcloudBackupRestoreProvider getRestoreProvider() {
 		if(!this.restoreProvider) {
-		this.restoreProvider = new UpcloudBackupRestoreProvider(getPlugin())
+		this.restoreProvider = new UpcloudBackupRestoreProvider(getPlugin(), getMorpheus())
 		}
 		return this.restoreProvider
 	}

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudCloudProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudCloudProvider.groovy
@@ -208,13 +208,13 @@ class UpcloudCloudProvider implements CloudProvider {
 							editable:false, global:false, placeHolder:null, helpBlock:'', defaultValue:null, custom:false, displayOrder:5, fieldClass:null),
 					new OptionType(code:"computeServerType.${this.getCode()}.lvmEnabled", inputType:OptionType.InputType.CHECKBOX, name:'lvmEnabled', category:"computeServerType.${this.getCode()}",
 							fieldName:'lvmEnabled', fieldCode: 'gomorpheus.optiontype.LvmEnabled?', fieldLabel:'LVM Enabled?', fieldContext:'server', fieldGroup:'Server Options', required:false, enabled:true, editable:false, global:false,
-							placeHolder:null, helpBlock:'', defaultValue:'on', custom:false, displayOrder:6, fieldClass:'lvm-enabled-checkbox', blockClass:'checkbox-container'),
+							placeHolder:null, helpBlock:'', defaultValue:'on', custom:false, displayOrder:6, fieldClass:'lvm-enabled-checkbox'),
 					new OptionType(code:"computeServerType.${this.getCode()}.dataDevice", inputType:OptionType.InputType.TEXT, name:'dataDevice', category:"computeServerType.${this.getCode()}",
 							fieldName:'dataDevice', fieldCode: 'gomorpheus.optiontype.DataVolume', fieldLabel:'Data Volume', fieldContext:'server', fieldGroup:'Server Options', required:true, enabled:true, editable:false, global:false,
 							placeHolder:null, helpBlock:'', defaultValue:'/dev/sdb', custom:false, displayOrder:7, fieldClass:null, wrapperClass:'lvm-server-options'),
 					new OptionType(code:"computeServerType.${this.getCode()}.softwareRaid", inputType:OptionType.InputType.CHECKBOX, name:'softwareRaid', category:"computeServerType.${this.getCode()}",
 							fieldName:'softwareRaid', fieldCode: 'gomorpheus.optiontype.SoftwareRaid', fieldLabel:'Software Raid', fieldContext:'server', fieldGroup:'Server Options', required:false, enabled:true, editable:false, global:false,
-							placeHolder:null, helpBlock:'', defaultValue:false, custom:false, displayOrder:8, fieldClass:null, wrapperClass:'lvm-server-options', blockClass:'checkbox-container'),
+							placeHolder:null, helpBlock:'', defaultValue:false, custom:false, displayOrder:8, fieldClass:null, wrapperClass:'lvm-server-options'),
 					new OptionType(code:"computeServerType.${this.getCode()}.network.name", inputType:OptionType.InputType.TEXT, name:'network name', category:"computeServerType.${this.getCode()}",
 							fieldName:'name', fieldCode: 'gomorpheus.optiontype.NetworkInterface', fieldLabel:'Network Interface', fieldContext:'network', fieldGroup:'Server Options', required:false, enabled:true, editable:false, global:false,
 							placeHolder:null, helpBlock:'', defaultValue:'eth0', custom:false, displayOrder:9, fieldClass:null)
@@ -511,7 +511,7 @@ class UpcloudCloudProvider implements CloudProvider {
 		log.debug("startServer: ${computeServer}")
 		def rtn = [success:false]
 		try {
-			return UpcloudProvisionProvider.startServer(computeServer)
+			return new UpcloudProvisionProvider(plugin, morpheus).startServer(computeServer)
 		} catch(e) {
 			rtn.msg = "Error starting server: ${e.message}"
 			log.error("startServer error: ${e}", e)
@@ -530,7 +530,7 @@ class UpcloudCloudProvider implements CloudProvider {
 		log.debug("stopServer: ${computeServer}")
 		def rtn = [success:false]
 		try {
-			return UpcloudProvisionProvider.stopServer(computeServer)
+			return new UpcloudProvisionProvider(plugin, morpheus).stopServer(computeServer)
 		} catch(e) {
 			rtn.msg = "Error stoping server: ${e.message}"
 			log.error("stopServer error: ${e}", e)

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudPlugin.groovy
@@ -45,7 +45,12 @@ class UpcloudPlugin extends Plugin {
      */
     @Override
     void onDestroy() {
-        //nothing to do for now
+        List<String> seedsToRun = [
+                "application.UpCloudZoneTypeSeed",
+                "application.ProvisionTypeUpcloudSeed",
+        ]
+        this.morpheus.services.seed.reinstallSeedData(seedsToRun)
+        // needs to be synchronous to prevent seeds from running during plugin install
     }
 
     Map getAuthConfig(Map args) {

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudProvisionProvider.groovy
@@ -16,6 +16,7 @@ import com.morpheusdata.model.ComputeServer
 import com.morpheusdata.model.ComputeServerInterface
 import com.morpheusdata.model.ComputeServerInterfaceType
 import com.morpheusdata.model.ComputeTypeSet
+import com.morpheusdata.model.HostType
 import com.morpheusdata.model.Icon
 import com.morpheusdata.model.Instance
 import com.morpheusdata.model.NetAddress
@@ -35,6 +36,7 @@ import com.morpheusdata.request.ResizeRequest
 import com.morpheusdata.response.PrepareWorkloadResponse
 import com.morpheusdata.response.ProvisionResponse
 import com.morpheusdata.response.ServiceResponse
+import com.morpheusdata.upcloud.datasets.UpcloudImageDatasetProvider
 import com.morpheusdata.upcloud.services.UpcloudApiService
 import groovy.util.logging.Slf4j
 import org.apache.tools.ant.types.spi.Service
@@ -121,8 +123,60 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	 */
 	@Override
 	Collection<OptionType> getNodeOptionTypes() {
-		Collection<OptionType> nodeOptions = []
-		return nodeOptions
+		OptionType osTypeOption = new OptionType([
+				name : 'osType',
+				code : 'upcloud-node-os-type',
+				fieldName : 'osType.id',
+				fieldContext : 'domain',
+				fieldLabel : 'OsType',
+				inputType : OptionType.InputType.SELECT,
+				displayOrder : 100,
+				required : false,
+				optionSource : 'osTypes'
+		])
+		OptionType imageOption = new OptionType([
+				name : 'image',
+				code : 'upcloud-node-image',
+				fieldName : 'virtualImage.id',
+				fieldContext : 'domain',
+				fieldLabel : 'Image',
+				inputType : OptionType.InputType.SELECT,
+				displayOrder : 99,
+				required : false,
+				optionSource : 'upcloud.upcloudImageDataset'
+		])
+		OptionType logFolder = new OptionType([
+				name : 'mountLogs',
+				code : 'upcloud-node-log-folder',
+				fieldName : 'mountLogs',
+				fieldContext : 'domain',
+				fieldLabel : 'Log Folder',
+				inputType : OptionType.InputType.TEXT,
+				displayOrder : 101,
+				required : false,
+		])
+		OptionType configFolder = new OptionType([
+				name : 'mountConfig',
+				code : 'upcloud-node-config-folder',
+				fieldName : 'mountConfig',
+				fieldContext : 'domain',
+				fieldLabel : 'Config Folder',
+				inputType : OptionType.InputType.TEXT,
+				displayOrder : 102,
+				required : false,
+		])
+		OptionType deployFolder = new OptionType([
+				name : 'mountData',
+				code : 'upcloud-node-deploy-folder',
+				fieldName : 'mountData',
+				fieldContext : 'domain',
+				fieldLabel : 'Deploy Folder',
+				inputType : OptionType.InputType.TEXT,
+				displayOrder : 103,
+				helpText: '(Optional) If using deployment services, this mount point will be replaced with the contents of said deployments.',
+				required : false,
+		])
+		return [osTypeOption, imageOption, logFolder, configFolder, deployFolder]
 	}
 
 	/**
@@ -189,6 +243,11 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	@Override
 	Boolean createDefaultInstanceType() {
 		return false
+	}
+
+	@Override
+	HostType getHostType() {
+		return HostType.vm
 	}
 
 	def buildDataDisk(volume) {

--- a/src/main/groovy/com/morpheusdata/upcloud/UpcloudProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/UpcloudProvisionProvider.groovy
@@ -3,6 +3,7 @@ package com.morpheusdata.upcloud
 import com.morpheusdata.core.AbstractProvisionProvider
 import com.morpheusdata.core.MorpheusContext
 import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.data.DataQuery
 import com.morpheusdata.core.providers.ProvisionProvider
 import com.morpheusdata.core.providers.WorkloadProvisionProvider
 import com.morpheusdata.core.util.ComputeUtility
@@ -36,6 +37,7 @@ import com.morpheusdata.response.ProvisionResponse
 import com.morpheusdata.response.ServiceResponse
 import com.morpheusdata.upcloud.services.UpcloudApiService
 import groovy.util.logging.Slf4j
+import org.apache.tools.ant.types.spi.Service
 
 @Slf4j
 class UpcloudProvisionProvider extends AbstractProvisionProvider implements WorkloadProvisionProvider, ProvisionProvider.BlockDeviceNameFacet {
@@ -105,7 +107,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 					fieldName:'noAgent', fieldCode: 'gomorpheus.optiontype.SkipAgentInstall', fieldLabel:'Skip Agent Install', fieldContext:'config', fieldGroup:'Advanced Options', required:false, enabled:true,
 					editable:false, global:false, placeHolder:null, helpBlock:'Skipping Agent installation will result in a lack of logging and guest operating system statistics. Automation scripts may also be adversely affected.', defaultValue:null, custom:false, displayOrder:4, fieldClass:null),
 			new OptionType(code:'containerType.upcloud.imageId', inputType:OptionType.InputType.SELECT, name:'imageType', category:'containerType.upcloud', optionSource: 'upcloudImage', optionSourceType:'upcloud',
-					fieldName:'imageId', fieldCode: 'gomorpheus.optiontype.Image', fieldLabel:'Image', fieldContext:'config', required:false, enabled:true, editable:false, global:false,
+					fieldName:'imageId', fieldCode: 'gomorpheus.optiontype.Image', fieldLabel:'Image', fieldContext:'config', required:true, enabled:true, editable:false, global:false,
 					placeHolder:null, helpBlock:'', defaultValue:null, custom:false, displayOrder:3, fieldClass:null)
 		]
 		// TODO: create some option types for provisioning and add them to collection
@@ -176,6 +178,45 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		return ServiceResponse.success()
 	}
 
+	Boolean canAddVolumes() {
+		return true
+	}
+
+	Boolean canCustomizeDataVolumes() {
+		return true
+	}
+
+	def buildDataDisk(volume) {
+		return [id:volume.id, diskType:volume?.type?.code ?: 'upcloudVolume', maxStorage:volume.maxStorage, name:volume.name,
+				deviceName:volume.deviceName, displayOrder:volume.displayOrder]
+	}
+
+	def buildDataDisks(volumes) {
+		def rtn = []
+		volumes?.each { volume ->
+			rtn << buildDataDisk(volume)
+		}
+		return rtn
+	}
+
+	def cleanInstanceName(name) {
+		def rtn = name.replaceAll(/[^a-zA-Z0-9\.\-]/,'')
+		return rtn
+	}
+
+	def insertImage(Map runConfig, Map opts) {
+		def taskResults = [success:false, imageId:runConfig.virtualImage.id, virtualImage:runConfig.virtualImage]
+		try {
+			log.info("imageUploadId: ${runConfig.virtualImage.id}")
+			taskResults.success = true
+			log.info("imageUploadTask: ${taskResults}")
+		} catch(imageException) {
+			log.error("imageException: ${imageException}", imageException)
+			taskResults.message = 'Error uploading image'
+		}
+		return taskResults
+	}
+
 	/**
 	 * This method is a key entry point in provisioning a workload. This could be a vm, a container, or something else.
 	 * Information associated with the passed Workload object is used to kick off the workload provision request
@@ -190,23 +231,147 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	ServiceResponse<ProvisionResponse> runWorkload(Workload workload, WorkloadRequest workloadRequest, Map opts) {
 		log.debug "runWorkload: ${workload} ${workloadRequest} ${opts}"
 		ProvisionResponse provisionResponse = new ProvisionResponse(success: true)
-		ComputeServer server = workload.server
-		try {
-			Cloud cloud = server.cloud
-			VirtualImage virtualImage = server.sourceImage
-			def runConfig = buildWorkloadRunConfig(workload, workloadRequest, virtualImage, opts)
 
-			runVirtualMachine(runConfig, provisionResponse, opts)
-			log.info("Checking Server Interfaces....")
-			workload.server.interfaces?.each { netInt ->
-				log.info("Net Interface: ${netInt.id} -> Network: ${netInt.network?.id}")
+//		ComputeServer server = workload.server
+//		try {
+//			Cloud cloud = server.cloud
+//			VirtualImage virtualImage = server.sourceImage
+//			def runConfig = buildWorkloadRunConfig(workload, workloadRequest, virtualImage, opts)
+//
+//			runVirtualMachine(runConfig, provisionResponse, opts)
+//			log.info("Checking Server Interfaces....")
+//			workload.server.interfaces?.each { netInt ->
+//				log.info("Net Interface: ${netInt.id} -> Network: ${netInt.network?.id}")
+//			}
+//			provisionResponse.noAgent = opts.noAgent ?: false
+//			return new ServiceResponse<ProvisionResponse>(success: true, data: provisionResponse)
+//		} catch (e) {
+//			log.error "runWorkload: ${e}", e
+//			provisionResponse.setError(e.message)
+//			return new ServiceResponse(success: false, msg: e.message, error: e.message, data: provisionResponse)
+//		}
+
+		try {
+			def containerConfig = workload.getConfigMap()
+			log.info("containerConfig: ${containerConfig}")
+			def server = workload.server
+			log.info("server: ${server}")
+			def cloud = server.cloud
+			log.info("cloud: ${cloud}")
+			def account = server.account
+			log.info("account: ${account}")
+			def cloudConfig = cloud.getConfigMap()
+			log.info("cloudConfig: ${cloudConfig}")
+
+			def authConfig = plugin.getAuthConfig(cloud)
+			opts.noAgent = containerConfig.noAgent
+			opts.findAdminPassword = true
+			def imageType = containerConfig.imageType ?: 'default'
+			def virtualImageId = (containerConfig.imageId?.toLong() ?: containerConfig.template?.toLong() ?: server.sourceImage.id)
+			def virtualImage = morpheus.async.virtualImage.get(virtualImageId).blockingGet()
+			if(virtualImage) {
+				def rootVolume = workload.server.volumes?.find{ it.rootVolume == true}
+				def dataDisks = workload.server.volumes?.findAll{ it.rootVolume == false}?.sort{it.id}
+				def servicePlan = workload.instance.plan
+				def runConfig = [
+						containerId: workload.id,
+						instanceId: workload.instance.id,
+						account: account,
+						zone: cloud,
+						name: cleanInstanceName(server.name),
+						zoneRef: cloudConfig.zone,
+						hostname: server.getExternalHostname(),
+						userData: null,
+						externalId: server.externalId,
+						serverId: server.id,
+						virtualImage: virtualImage,
+						dataDisks: dataDisks,
+						rootVolume: rootVolume,
+						container: workload,
+						callbackService: opts.callbackService,
+						server: workload.server,
+						diskList: [],
+						domainName: server.getExternalDomain(),
+						authConfig: authConfig,
+						serverInterfaces: server.interfaces,
+						osType: (virtualImage.osType?.platform?.toString() == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
+						platform: (virtualImage.osType?.platform?.toString() == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
+						//userConfig: workloadRequest.usersConfiguration
+				]
+
+				if(servicePlan.internalId == 'custom') {
+					runConfig.maxMemory = workload.maxMemory ?: servicePlan.maxMemory
+					runConfig.maxCores = workload.maxCores ?: servicePlan.maxCores
+				} else {
+					runConfig.planRef = servicePlan.externalId
+					runConfig.tier = servicePlan.getConfigProperty('tier')
+				}
+				runConfig.fqdn = runConfig.hostName + '.' + runConfig.domainName
+
+				log.info("runConfig: ${runConfig}")
+
+				if(opts.cloneContainerId && opts.backupSetId) {
+					def snapshot = morpheus.services.backup.backupResult.list(
+							new DataQuery().withFilter("backupSetId", opts.backupSetId)
+							.withFilter("containerId", opts.cloneContainerId)
+					).find{ it.backupSetId == opts.backupSetId }
+					def rootSnapshot = snapshot?.snapshotList?.find{ it.root }
+					if(rootSnapshot && rootSnapshot.storageId) {
+						log.info("creating server from snapshot image: ${rootSnapshot.storageId}")
+						runConfig.cloneImageId = rootSnapshot.storageId
+					}
+					// Handle any data disks
+					def dataSnapshots = snapshot?.snapshotList?.findAll { !it.root }
+					dataSnapshots?.each { dataSnapshot ->
+						def dataDisk = runConfig.dataDisks?.find { !it.snapshotUUID && (int)it.maxStorage.div(ComputeUtility.ONE_GIGABYTE) == (int)dataSnapshot.sizeInGb }
+						dataDisk.snapshotUUID = dataSnapshot.storageId
+					}
+				}
+				// upload or insert image
+				def imageUploadResults = insertImage(runConfig, opts)
+				log.info("insertImage results: ${imageUploadResults}")
+
+				if(imageUploadResults.success == true) {
+					try {
+						log.info("imageUploadTask onComplete: ${imageUploadResults}")
+						if (imageUploadResults.success == true && imageUploadResults.imageId) {
+							log.info("imageUploadResults.virtualImage.id: ${imageUploadResults?.virtualImage}, ${imageUploadResults?.virtualImage?.id}")
+							log.info("runConfig.virtualImage.id: ${runConfig.virtualImage.id}")
+							runConfig.virtualImage = morpheus.async.virtualImage.get(imageUploadResults?.virtualImage?.id ?: runConfig.virtualImage.id).blockingGet()
+							log.info("runConfig.virtualImage: ${runConfig.virtualImage}")
+							runConfig.imageRef = runConfig.virtualImage.externalId
+							opts.installAgent = opts.noAgent ? false : runConfig.virtualImage.installAgent
+
+							runVirtualMachine(runConfig, provisionResponse, opts)
+							log.info("after run virtual machine")
+						} else {
+							provisionResponse.setError(imageUploadResults.message)
+							return new ServiceResponse(success: false, msg: imageUploadResults.message, e: null, data: provisionResponse)
+						}
+					} catch (e) {
+						provisionResponse.setError("failed to acquire additional virtual image information: ${e}")
+						return new ServiceResponse(success: false, msg: "failed to acquire additional virtual image information: ${e}", error: e, data: provisionResponse)
+					}
+				} else {
+					log.error("image upload task error: ${imageUploadResults.message}")
+					provisionResponse.setError("failed to upload image file")
+					return new ServiceResponse(success: false, msg: 'failed to upload image file', error: null, data: provisionResponse)
+				}
+
+			} else {
+				provisionResponse.setError("virtual image not found")
+				return new ServiceResponse(success: false, msg: 'virtual image not found', error: null, data: provisionResponse)
 			}
-			provisionResponse.noAgent = opts.noAgent ?: false
-			return new ServiceResponse<ProvisionResponse>(success: true, data: provisionResponse)
+
+			if(provisionResponse.success != true) {
+				return new ServiceResponse(success: false, msg: provisionResponse.message ?: 'vm config error', error: provisionResponse.message, data: provisionResponse)
+			} else {
+				return new ServiceResponse<ProvisionResponse>(success: true, data: provisionResponse)
+			}
 		} catch (e) {
-			log.error "runWorkload: ${e}", e
-			provisionResponse.setError(e.message)
-			return new ServiceResponse(success: false, msg: e.message, error: e.message, data: provisionResponse)
+			log.error "runWorkload error: ${e}", e
+			provisionResponse.setError("Failed to create server: ${e.message}")
+			return new ServiceResponse(success: false, msg: e.message, error: e, data: provisionResponse)
 		}
 	}
 
@@ -233,7 +398,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 			if(workload.server?.externalId) {
 				def authConfigMap = plugin.getAuthConfig(workload.server?.cloud)
 				def statusResults = UpcloudApiService.waitForServerNotStatus(authConfigMap, workload.server.externalId, 'maintenance')
-				def stopResults = UpcloudProvisionProvider.stopServer(workload.server)
+				def stopResults = stopServer(workload.server)
 				if(stopResults.success == true) {
 					rtn.success = true
 				}
@@ -261,7 +426,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 			if(workload.server?.externalId) {
 				def authConfigMap = plugin.getAuthConfig(workload.server?.cloud)
 				def statusResults = UpcloudApiService.waitForServerNotStatus(authConfigMap, workload.server.externalId, 'maintenance')
-				def startResults = UpcloudProvisionProvider.startServer(workload.server)
+				def startResults = startServer(workload.server)
 				log.debug("startWorkload: startResults: ${startResults}")
 				if(startResults.success == true) {
 					rtn.success = true
@@ -353,13 +518,16 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	 */
 	@Override
 	ServiceResponse stopServer(ComputeServer computeServer) {
-		log.debug("stopServer: ${computeServer}")
+		log.info("calling stop server provision provider: ${computeServer}")
 		if(computeServer.managed == true || computeServer.computeServerType?.controlPower) {
 			def authConfig = plugin.getAuthConfig(computeServer.cloud)
 			def statusResults = UpcloudApiService.waitForServerNotStatus(authConfig, computeServer.externalId, 'maintenance')
+			log.info("status results: ${statusResults}")
 			def stopResults = UpcloudApiService.stopServer(authConfig, computeServer.externalId)
+			log.info("stop results: ${stopResults}")
 			if (stopResults.success) {
 				def waitResults = UpcloudApiService.waitForServerStatus(authConfig, computeServer.externalId, 'stopped')
+				log.info("wait results: ${waitResults}")
 				if(waitResults.success) {
 					return ServiceResponse.success()
 				} else {
@@ -371,7 +539,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		} else {
 			log.info("stopServer - ignoring request for unmanaged instance")
 		}
-		ServiceResponse.success()
+		return ServiceResponse.success()
 	}
 
 	/**
@@ -381,13 +549,16 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	 */
 	@Override
 	ServiceResponse startServer(ComputeServer computeServer) {
-		log.debug("startServer: ${computeServer}")
+		log.info("calling start server provision provider: ${computeServer}")
 		if(computeServer.managed == true || computeServer.computeServerType?.controlPower) {
 			def authConfig = plugin.getAuthConfig(computeServer.cloud)
 			def statusResults = UpcloudApiService.waitForServerNotStatus(authConfig, computeServer.externalId, 'maintenance')
+			log.info("status results: ${statusResults}")
 			def startResults = UpcloudApiService.startServer(authConfig, computeServer.externalId)
+			log.info("start results: ${startResults}")
 			if(startResults.success == true) {
 				def waitResults = UpcloudApiService.waitForServerStatus(authConfig, computeServer.externalId, 'running')
+				log.info("wait results: ${waitResults}")
 				if(waitResults.success) {
 					return ServiceResponse.success()
 				} else {
@@ -399,7 +570,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		} else {
 			log.info("startServer - ignoring request for unmanaged instance")
 		}
-		ServiceResponse.success()
+		return ServiceResponse.success()
 	}
 
 	/**
@@ -462,7 +633,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		def taskResults = [success:false]
 		ComputeServer server = runConfig.server
 		Account account = server.account
-		opts.createUserList = runConfig.userConfig.createUsers
+		//opts.createUserList = runConfig.userConfig.createUsers
 
 		//save server
 		// runConfig.server = saveAndGet(server)
@@ -470,30 +641,37 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 
 		//set install agent
 		runConfig.installAgent = runConfig.noAgent && server.cloud.agentMode != 'cloudInit'
-
+		log.info("RUNCONFIG ROOT VOLUME DISK TYPE: ${runConfig.rootVolume.diskType}")
 		def createResults = UpcloudApiService.createServer(runConfig.authConfig, runConfig)
 		log.info("create server results success ${createResults.success}")
 		log.debug("Upcloud Create Server Results: {}",createResults)
 		if(createResults.success == true && createResults.server) {
 			server.externalId = createResults.externalId
 			server.sshPassword = createResults.server.password ?: runConfig.server.sshPassword
-			server.region = new CloudRegion(code: server.resourcePool.regionCode)
+			//server.region = new CloudRegion(code: server.resourcePool.regionCode)
 			provisionResponse.externalId = server.externalId
 			server = saveAndGet(server)
 			runConfig.server = server
 
 			UpcloudApiService.waitForServerExists(runConfig.authConfig, createResults.externalId)
+			log.info("wait for server exists complete")
 			// wait for ready
 			def statusResults = UpcloudApiService.checkServerReady(runConfig.authConfig, createResults.externalId)
+			log.info("check server ready: ${statusResults.success}")
 			if (statusResults.success == true) {
 				//good to go
 				def serverDetails = UpcloudApiService.getServerDetail(runConfig.authConfig, createResults.externalId)
+				log.info("server details success: ${serverDetails.success}")
 				if (serverDetails.success == true) {
 					log.debug("server details: {}", serverDetails)
+					log.info("server detail networks: ${serverDetails.networks}")
+					log.info("server detail server: ${serverDetails.server}")
+
 					//update volume info
-					setRootVolumeInfo(runConfig.rootVolume, serverDetails.server)
+					setRootVolumeInfo(runConfig.rootVolume, runConfig.platform, serverDetails.volumes)
 					setVolumeInfo(runConfig.dataDisks, serverDetails.volumes)
 					setNetworkInfo(runConfig.serverInterfaces, serverDetails.networks)
+					log.info("volume info updated")
 					//update network info
 					def privateIp = serverDetails.server.'ip_addresses'?.'ip_address'?.find {
 						it.family == 'IPv4' && it.access == 'utility'
@@ -501,8 +679,11 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 					def publicIp = serverDetails.server.'ip_addresses'?.'ip_address'?.find {
 						it.family == 'IPv4' && it.access == 'public'
 					}
+					log.info("private ip: ${privateIp}")
+					log.info("public ip: ${publicIp}")
+					log.info("network info updated")
 					def serverConfigOpts = [:]
-					applyComputeServerNetwork(server, privateIp, publicIp, null, null, serverConfigOpts)
+					applyComputeServerNetwork(server, privateIp.address, publicIp.address, null, null, serverConfigOpts)
 					taskResults.server = createResults.server
 					taskResults.success = true
 
@@ -515,6 +696,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		} else {
 			taskResults.message = createResults.msg
 		}
+		log.info("task results success: ${taskResults.success}, server: ${taskResults.server}")
 		return taskResults
 
 	}
@@ -522,6 +704,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	def finalizeVm(Map runConfig, ProvisionResponse provisionResponse, Map runResults) {
 		log.debug("runTask onComplete: provisionResponse: ${provisionResponse}")
 		ComputeServer server = context.async.computeServer.get(runConfig.serverId).blockingGet()
+		log.info("finalize vm server: ${server}")
 		try {
 			if(provisionResponse.success == true) {
 				server.status = 'provisioned'
@@ -530,7 +713,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 				server.osDevice = '/dev/vda'
 				server.lvmEnabled = server.volumes?.size() > 1
 				server.managed = true
-				server.capacityInfo = new ComputeCapacityInfo(server:server, maxCores:server.plan?.maxCores ?: 1, maxMemory:server.plan?.maxMemory ?: ComputeUtility.ONE_GIGABYTE, maxStorage:runConfig.maxStorage)
+				server.capacityInfo = new ComputeCapacityInfo(maxCores:server.plan?.maxCores ?: 1, maxMemory:server.plan?.maxMemory ?: ComputeUtility.ONE_GIGABYTE, maxStorage:runConfig.maxStorage)
 				saveAndGet(server)
 			}
 		} catch(e) {
@@ -627,6 +810,8 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 	}
 
 	private applyComputeServerNetwork(server, privateIp, publicIp = null, hostname = null, networkPoolId = null, configOpts = [:], index = 0, networkOpts = [:]) {
+		log.info("private ip in apply: ${privateIp}")
+		log.info("public ip in apply: ${publicIp}")
 		configOpts.each { k,v ->
 			server.setConfigProperty(k, v)
 		}
@@ -684,95 +869,96 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		return network
 	}
 
-	protected buildWorkloadRunConfig(Workload workload, WorkloadRequest workloadRequest, VirtualImage virtualImage, Map opts) {
-		log.debug("buildRunConfig: {}, {}, {}, {}", workload, workloadRequest, virtualImage, opts)
-		Map workloadConfig = workload.getConfigMap()
-		ComputeServer server = workload.server
-		Cloud cloud = server.cloud
-		StorageVolume rootVolume = server.volumes?.find{it.rootVolume == true}
+//	protected buildWorkloadRunConfig(Workload workload, WorkloadRequest workloadRequest, VirtualImage virtualImage, Map opts) {
+//		log.debug("buildRunConfig: {}, {}, {}, {}", workload, workloadRequest, virtualImage, opts)
+//		Map workloadConfig = workload.getConfigMap()
+//		ComputeServer server = workload.server
+//		Cloud cloud = server.cloud
+//		StorageVolume rootVolume = server.volumes?.find{it.rootVolume == true}
+//
+//		def maxMemory = server.maxMemory?.div(ComputeUtility.ONE_MEGABYTE)
+//		def maxStorage = rootVolume?.getMaxStorage() ?: opts.config?.maxStorage ?: server.plan.maxStorage
+//
+//		def runConfig = [:] + opts + buildRunConfig(server, virtualImage, workloadRequest.networkConfiguration, workloadConfig, opts)
+//
+//		runConfig += [
+//				name              : server.name,
+//				instanceId		  : workload.instance.id,
+//				containerId       : workload.id,
+//				account 		  : server.account,
+//				maxStorage        : maxStorage,
+//				maxMemory		  : maxMemory,
+//				applianceServerUrl: workloadRequest.cloudConfigOpts?.applianceUrl,
+//				workloadConfig    : workload.getConfigMap(),
+//				timezone          : (server.getConfigProperty('timezone') ?: cloud.timezone),
+//				proxySettings     : workloadRequest.proxyConfiguration,
+//				noAgent           : (opts.config?.containsKey("noAgent") == true && opts.config.noAgent == true),
+//				installAgent      : (opts.config?.containsKey("noAgent") == false || (opts.config?.containsKey("noAgent") && opts.config.noAgent != true)),
+//				userConfig        : workloadRequest.usersConfiguration,
+//				cloudConfig	      : workloadRequest.cloudConfigUser,
+//				networkConfig	  : workloadRequest.networkConfiguration
+//		]
+//
+//		return runConfig
+//
+//	}
 
-		def maxMemory = server.maxMemory?.div(ComputeUtility.ONE_MEGABYTE)
-		def maxStorage = rootVolume?.getMaxStorage() ?: opts.config?.maxStorage ?: server.plan.maxStorage
-
-		def runConfig = [:] + opts + buildRunConfig(server, virtualImage, workloadRequest.networkConfiguration, workloadConfig, opts)
-
-		runConfig += [
-				name              : server.name,
-				instanceId		  : workload.instance.id,
-				containerId       : workload.id,
-				account 		  : server.account,
-				maxStorage        : maxStorage,
-				maxMemory		  : maxMemory,
-				applianceServerUrl: workloadRequest.cloudConfigOpts?.applianceUrl,
-				workloadConfig    : workload.getConfigMap(),
-				timezone          : (server.getConfigProperty('timezone') ?: cloud.timezone),
-				proxySettings     : workloadRequest.proxyConfiguration,
-				noAgent           : (opts.config?.containsKey("noAgent") == true && opts.config.noAgent == true),
-				installAgent      : (opts.config?.containsKey("noAgent") == false || (opts.config?.containsKey("noAgent") && opts.config.noAgent != true)),
-				userConfig        : workloadRequest.usersConfiguration,
-				cloudConfig	      : workloadRequest.cloudConfigUser,
-				networkConfig	  : workloadRequest.networkConfiguration
-		]
-
-		return runConfig
-
-	}
-
-	protected buildRunConfig(ComputeServer server, VirtualImage virtualImage, NetworkConfiguration networkConfiguration, config, Map opts) {
-		log.debug("buildRunConfig: {}, {}, {}, {}, {}", server, virtualImage, networkConfiguration, config, opts)
-		def rootVolume = server.volumes?.find{it.rootVolume == true}
-		def dataDisks = server?.volumes?.findAll{it.rootVolume == false}?.sort{it.id}
-		def maxStorage
-		if(rootVolume) {
-			maxStorage = rootVolume.maxStorage
-		} else {
-			maxStorage = config.maxStorage ?: server.plan.maxStorage
-		}
-
-		def runConfig = [
-				serverId: server.id,
-				name: server.name,
-				vpcRef: server.resourcePool?.externalId,
-				zoneRef: server.cloudConfig.cloud,
-				server: server,
-				imageType: virtualImage.imageType,
-				osType: (virtualImage.osType?.platform == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
-				platform: (virtualImage.osType?.platform == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
-				kmsKeyId: config.kmsKeyId,
-				osDiskSize : maxStorage.div(ComputeUtility.ONE_GIGABYTE),
-				maxStorage : maxStorage,
-				osDiskType: rootVolume?.type?.name ?: 'gp2',
-				iops: rootVolume?.maxIOPS,
-				osDiskName:'/dev/sda1',
-				dataDisks: dataDisks,
-				rootVolume:rootVolume,
-				//cachePath: virtualImageService.getLocalCachePath(),
-				virtualImage: virtualImage,
-				hostname: server.getExternalHostname(),
-				hosts: server.getExternalHostname(),
-				diskList:[],
-				domainName: server.getExternalDomain(),
-				securityGroups: config.securityGroups,
-				serverInterfaces:server.interfaces,
-				publicIpType: config.publicIpType ?: 'subnet',
-				fqdn: server.getExternalHostname() + '.' + server.getExternalDomain(),
-		]
-
-		log.debug("Setting snapshot image refs opts.snapshotImageRef: ${opts.snapshotImageRef},  ${opts.rootSnapshotId}")
-		if(opts.snapshotImageRef) {
-			// restore from a snapshot
-			runConfig.imageRef = opts.snapshotImageRef
-			runConfig.osDiskSnapshot = opts.rootSnapshotId
-		} else {
-			// use selected provision image
-			runConfig.imageRef = runConfig.virtualImageLocation.externalId
-			runConfig.osDiskSnapshot = runConfig.virtualImageLocation.externalDiskId
-		}
-
-		return runConfig
-	}
+//	protected buildRunConfig(ComputeServer server, VirtualImage virtualImage, NetworkConfiguration networkConfiguration, config, Map opts) {
+//		log.debug("buildRunConfig: {}, {}, {}, {}, {}", server, virtualImage, networkConfiguration, config, opts)
+//		def rootVolume = server.volumes?.find{it.rootVolume == true}
+//		def dataDisks = server?.volumes?.findAll{it.rootVolume == false}?.sort{it.id}
+//		def maxStorage
+//		if(rootVolume) {
+//			maxStorage = rootVolume.maxStorage
+//		} else {
+//			maxStorage = config.maxStorage ?: server.plan.maxStorage
+//		}
+//
+//		def runConfig = [
+//				serverId: server.id,
+//				name: server.name,
+//				vpcRef: server.resourcePool?.externalId,
+//				zoneRef: server.cloud,
+//				server: server,
+//				imageType: virtualImage.imageType,
+//				osType: (virtualImage.osType?.platform == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
+//				platform: (virtualImage.osType?.platform == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform,
+//				kmsKeyId: config.kmsKeyId,
+//				osDiskSize : maxStorage.div(ComputeUtility.ONE_GIGABYTE),
+//				maxStorage : maxStorage,
+//				osDiskType: rootVolume?.type?.name ?: 'gp2',
+//				iops: rootVolume?.maxIOPS,
+//				osDiskName:'/dev/sda1',
+//				dataDisks: dataDisks,
+//				rootVolume:rootVolume,
+//				//cachePath: virtualImageService.getLocalCachePath(),
+//				virtualImage: virtualImage,
+//				hostname: server.getExternalHostname(),
+//				hosts: server.getExternalHostname(),
+//				diskList:[],
+//				domainName: server.getExternalDomain(),
+//				securityGroups: config.securityGroups,
+//				serverInterfaces:server.interfaces,
+//				publicIpType: config.publicIpType ?: 'subnet',
+//				fqdn: server.getExternalHostname() + '.' + server.getExternalDomain(),
+//		]
+//
+//		log.debug("Setting snapshot image refs opts.snapshotImageRef: ${opts.snapshotImageRef},  ${opts.rootSnapshotId}")
+//		if(opts.snapshotImageRef) {
+//			// restore from a snapshot
+//			runConfig.imageRef = opts.snapshotImageRef
+//			runConfig.osDiskSnapshot = opts.rootSnapshotId
+//		} else {
+//			// use selected provision image
+//			runConfig.imageRef = runConfig.virtualImageLocation.externalId
+//			runConfig.osDiskSnapshot = runConfig.virtualImageLocation.externalDiskId
+//		}
+//
+//		return runConfig
+//	}
 
 	private void runVirtualMachine(Map runConfig, ProvisionResponse provisionResponse, Map opts) {
+		log.info("in run virtual machine 921")
 		try {
 			// don't think this used
 			// runConfig.template = runConfig.imageId
@@ -786,7 +972,6 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		}
 	}
 
-	@Override
 	ServiceResponse<ProvisionResponse> runHost(ComputeServer server, HostRequest hostRequest, Map opts) {
 		log.debug("runHost: ${server} ${hostRequest} ${opts}")
 
@@ -849,6 +1034,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 						zone		: cloud,
 						dataDisks	: dataDisks,
 						externalId	: server.externalId,
+						zoneRef		: server.cloud,
 				]
 				//cloud init config
 				createOpts.hostname = server.getExternalHostname()
@@ -858,6 +1044,7 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 				createOpts.networkConfig = hostRequest.networkConfiguration
 				createOpts.osType = (virtualImage.osType?.platform == 'windows' ? 'windows' : 'linux') ?: virtualImage.platform
 				createOpts.platform = createOpts.osType
+				//createOpts.userConfig = hostRequest.usersConfiguration
 
 				context.async.computeServer.save(server).blockingGet()
 				//create it
@@ -878,7 +1065,6 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		}
 	}
 
-	@Override
 	ServiceResponse resizeWorkload(Instance instance, Workload workload, ResizeRequest resizeRequest, Map opts) {
 		def server = morpheus.async.computeServer.get(workload.server.id).blockingGet()
 		if(server) {
@@ -888,7 +1074,6 @@ class UpcloudProvisionProvider extends AbstractProvisionProvider implements Work
 		}
 	}
 
-	@Override
 	ServiceResponse resizeServer(ComputeServer server, ResizeRequest resizeRequest, Map opts = [:]) {
 		return internalResizeServer(server, resizeRequest)
 	}

--- a/src/main/groovy/com/morpheusdata/upcloud/datasets/UpcloudImageDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/datasets/UpcloudImageDatasetProvider.groovy
@@ -90,7 +90,6 @@ class UpcloudImageDatasetProvider extends AbstractDatasetProvider<VirtualImage, 
 
     DataQuery buildQuery(DatasetQuery datasetQuery) {
         Long cloudId = datasetQuery.get("zoneId")?.toLong()
-        List<String> supportedImageTypes = getImageTypes()
         DataQuery query  = new DatasetQuery().withFilters(
                 new DataOrFilter(
                         new DataFilter("visibility", "public"),

--- a/src/main/groovy/com/morpheusdata/upcloud/services/UpcloudApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/services/UpcloudApiService.groovy
@@ -343,8 +343,8 @@ class UpcloudApiService {
             }
             //user data
             callOpts.body.server.metadata = 'yes'
-            if(serverConfig.userData)
-                callOpts.body.server.user_data = serverConfig.userData
+            if(serverConfig.cloudConfig)
+                callOpts.body.server.user_data = serverConfig.cloudConfig
             //create server
             log.debug("callOpts: ${callOpts}")
             def callResults = callApi(authConfig, callPath, callOpts, 'POST')

--- a/src/main/groovy/com/morpheusdata/upcloud/services/UpcloudApiService.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/services/UpcloudApiService.groovy
@@ -330,13 +330,15 @@ class UpcloudApiService {
                 }
             }
             //ssh key
-            if(serverConfig.userConfig?.keyList) {
-                serverConfig.userConfig.keyList.each {
-                    callOpts.body.server.login_user.ssh_keys.ssh_key << it
-                }
-            } else if(serverConfig.sshKey) {
-                callOpts.body.server.login_user.ssh_keys.ssh_key << serverConfig.sshKey
-            } else if(serverConfig.userConfig?.primaryKey?.publicKey) {
+//            if(serverConfig.userConfig?.keyList) {
+//                serverConfig.userConfig.keyList.each {
+//                    callOpts.body.server.login_user.ssh_keys.ssh_key << it
+//                }
+//            } else if(serverConfig.sshKey) {
+//                callOpts.body.server.login_user.ssh_keys.ssh_key << serverConfig.sshKey
+//            } else
+
+            if(serverConfig.userConfig?.primaryKey?.publicKey) {
                 callOpts.body.server.login_user.ssh_keys.ssh_key << serverConfig.userConfig.primaryKey.publicKey
             }
             //user data

--- a/src/main/groovy/com/morpheusdata/upcloud/sync/PublicTemplatesSync.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/sync/PublicTemplatesSync.groovy
@@ -44,6 +44,8 @@ class PublicTemplatesSync {
                 SyncTask<VirtualImageIdentityProjection, Map, VirtualImage> syncTask = new SyncTask<>(imageRecords, imageResults.data.storages.storage as Collection<Map>) as SyncTask<VirtualImageIdentityProjection, Map, VirtualImage>
                 syncTask.addMatchFunction { VirtualImageIdentityProjection imageObject, Map cloudItem ->
                     imageObject.externalId == cloudItem?.uuid
+                    log.info("morpheusItem.externalId: ${imageObject.externalId}")
+                    log.info("cloudItem.uuid: ${cloudItem.uuid}")
                 }.withLoadObjectDetailsFromFinder { List<SyncTask.UpdateItemDto<VirtualImageIdentityProjection, Map>> updateItems ->
                     morpheusContext.async.virtualImage.listById(updateItems.collect { it.existingItem.id } as List<Long>)
                 }.onAdd { itemsToAdd ->

--- a/src/main/groovy/com/morpheusdata/upcloud/util/UpcloudComputeUtility.groovy
+++ b/src/main/groovy/com/morpheusdata/upcloud/util/UpcloudComputeUtility.groovy
@@ -23,6 +23,7 @@ class UpcloudComputeUtility {
     static requestTimeout = 300000 //5 minutes?
 
     static getServerDetail(Map authConfig, String serverId) {
+        log.info("in get server detail")
         def rtn = [success:false]
         try {
             def callOpts = [:]

--- a/src/main/resources/scribe/upcloud-compute-types.scribe
+++ b/src/main/resources/scribe/upcloud-compute-types.scribe
@@ -1,0 +1,605 @@
+//docker host
+resource "workload-type" "docker-upcloud-ubuntu-16_04" {
+    code             = "docker-upcloud-ubuntu-16.04"
+    shortName        = "ubuntu"
+    name             = "Docker Ubuntu 16.04"
+    ports            = [22]
+    containerVersion = "16.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 16.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+}
+
+resource "compute-type-set" "docker-upcloud-ubuntu-16_04-set" {
+    code                    = "docker-upcloud-ubuntu-16.04-set"
+    name                    = "docker host"
+    workloadType            = workload-type.docker-upcloud-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-linux
+    category                = "ubuntu"
+    priorityOrder           = 0
+    dynamicCount            = true
+    nodeCount               = 1
+    nodeType                = "worker"
+    canAddNodes             = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-layout" "docker-upcloud-ubuntu-16_04-single" {
+    code              = "docker-upcloud-ubuntu-16.04-single"
+    name              = "UpCloud Docker Host"
+    sortOrder         = 5
+    computeVersion    = "16.04"
+    description       = "This will provision a single docker host vm in upcloud"
+    type              = compute-server-type.upcloud-linux
+    serverCount       = 1
+    memoryRequirement = 1024 * 1024 * 1024
+    hasAutoScale      = true
+    groupType         = compute-server-group-type.docker-cluster
+    computeServers    = ["docker-upcloud-ubuntu-16.04-set"]
+    provisionType     = "upcloud"
+}
+
+//kubernetes master - weave - openebs
+resource "workload-type" "kubernetes-upcloud-ubuntu-16_04" {
+    code             = "kubernetes-upcloud-ubuntu-16.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes 1.14 Cluster on Ubuntu 16.04"
+    containerVersion = "16.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 16.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-install-curl-1_14_1"},
+        {code = "kube-kubeadm-init"},
+        {code = "kube-kubeadm-copy-config"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-install-openebs-1-0-0-curl"},
+        {code = "kube-kubeadm-create-service-account"},
+        {code = "kube-kubeadm-check-pods"},
+        {code = "kube-kubeadm-install-weave"},
+        {code = "kube-kubeadm-install-openebs-1-0-0"},
+        {code = "kube-install-fluentbit"}
+    ]
+    templates = [
+        {code = "kube-logging-fluentbit-service-spec"},
+        {code = "kube-logging-fluentbit-role-spec"},
+        {code = "kube-logging-fluentbit-role-binding-spec"},
+        {code = "kube-logging-fluentbit-config-spec"},
+        {code = "kube-logging-fluentbit-daemon-spec"}
+    ]
+}
+
+resource "workload-type" "kubernetes-upcloud-worker-ubuntu-16_04" {
+    code             = "kubernetes-upcloud-worker-ubuntu-16.04"
+    shortName        = "kubernetes-worker-ubuntu"
+    name             = "Kubernetes Worker 1.14 on Ubuntu 16.04"
+    containerVersion = "16.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 16.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-install-curl-1_14_1"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-worker-join"}
+    ]
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ubuntu-16_04-set" {
+    code                    = "kubernetes-upcloud-ubuntu-16.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 0
+    dynamicCount            = false
+    nodeCount               = 1
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-worker-upcloud-ubuntu-16_04-set" {
+    code                    = "kubernetes-worker-upcloud-ubuntu-16.04-set"
+    name                    = "kubernetes worker"
+    workloadType            = workload-type.kubernetes-upcloud-worker-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-kube-worker
+    category                = "ubuntu"
+    priorityOrder           = 1
+    dynamicCount            = true
+    nodeCount               = 3
+    nameSuffix              = "-worker"
+    nodeType                = "worker"
+    canAddNodes             = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-layout" "kubernetes-upcloud-ubuntu-16_04-single" {
+    code              = "kubernetes-upcloud-ubuntu-16.04-single"
+    name              = "Kubernetes 1.14 Cluster on Ubuntu 16.04, Weave, OpenEBS"
+    sortOrder         = 40
+    computeVersion    = "16.04"
+    description       = "This will provision a single kubernetes master in upcloud with weave and openebs"
+    type              = compute-server-type.upcloud-kube-master
+    serverCount       = 4
+    memoryRequirement = 1024 * 1024 * 1024
+    hasAutoScale      = true
+    enabled           = false
+    creatable         = false
+    groupType         = compute-server-group-type.kubernetes-cluster
+    computeServers    = [
+        {code = "kubernetes-upcloud-ubuntu-16.04-set"},
+        {code = "kubernetes-worker-upcloud-ubuntu-16.04-set"}
+    ]
+    provisionType     = "upcloud"
+    optionTypes       = [{code = "kubernetes.master.podCidr"}]
+}
+
+//kubernetes ha cluster - weave - openebs
+resource "workload-type" "kubernetes-upcloud-ha-master-ubuntu-16_04" {
+    code             = "kubernetes-upcloud-ha-master-ubuntu-16.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes HA Master 1.14 on Ubuntu 16.04"
+    containerVersion = "16.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 16.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-cluster-master-prep"},
+        {code = "kube-kubeadm-cluster-shared-key"},
+        {code = "kube-kubeadm-install-curl-1_14_1"},
+        {code = "kube-kubeadm-cluster-master-init-1_14_1"},
+        {code = "kube-kubeadm-copy-config"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-install-openebs-1-0-0-curl"},
+        {code = "kube-kubeadm-create-service-account"},
+        {code = "kube-kubeadm-check-pods"},
+        {code = "kube-kubeadm-cluster-install-weave"},
+        {code = "kube-kubeadm-cluster-install-openebs-1-0-0"},
+        {code = "kube-install-fluentbit"}
+    ]
+    templates = [
+        {code = "kube-kubeadm-cluster-master-config-1_14_1"},
+        {code = "kube-logging-fluentbit-service-spec"},
+        {code = "kube-logging-fluentbit-role-spec"},
+        {code = "kube-logging-fluentbit-role-binding-spec"},
+        {code = "kube-logging-fluentbit-config-spec"},
+        {code = "kube-logging-fluentbit-daemon-spec"}
+    ]
+}
+
+resource "workload-type" "kubernetes-upcloud-ha-add-master-ubuntu-16_04" {
+    code             = "kubernetes-upcloud-ha-add-master-ubuntu-16.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes HA Add Master 1.14 on Ubuntu 16.04"
+    containerVersion = "16.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 16.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-cluster-master-prep"},
+        {code = "kube-kubeadm-cluster-shared-key"},
+        {code = "kube-kubeadm-install-curl-1_14_1"},
+        {code = "kube-kubeadm-cluster-add-master-certs"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-cluster-add-master-init-1_14_1"},
+        {code = "kube-kubeadm-copy-config"}
+    ]
+    templates = [{code = "kube-kubeadm-cluster-add-master-config-1_14_1"}]
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ha-master-ubuntu-16_04-set" {
+    code                    = "kubernetes-upcloud-ha-master-ubuntu-16.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ha-master-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 0
+    dynamicCount            = false
+    nodeCount               = 1
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    forceNameIndex          = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ha-add-master-ubuntu-16_04-set" {
+    code                    = "kubernetes-upcloud-ha-add-master-ubuntu-16.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ha-add-master-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 1
+    dynamicCount            = false
+    nodeCount               = 2
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    forceNameIndex          = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-worker-upcloud-ha-ubuntu-16_04-set" {
+    code                    = "kubernetes-worker-upcloud-ha-ubuntu-16.04-set"
+    name                    = "kubernetes worker"
+    workloadType            = workload-type.kubernetes-upcloud-worker-ubuntu-16_04
+    computeServerType       = compute-server-type.upcloud-kube-worker
+    category                = "ubuntu"
+    priorityOrder           = 2
+    dynamicCount            = true
+    nodeCount               = 3
+    nameSuffix              = "-worker"
+    nodeType                = "worker"
+    forceNameIndex          = true
+    canAddNodes             = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-layout" "kubernetes-upcloud-ubuntu-16_04-cluster-weave-openebs" {
+    code              = "kubernetes-upcloud-ubuntu-16.04-cluster-weave-openebs"
+    name              = "Kubernetes 1.14 HA Cluster on Ubuntu 16.04, Weave, OpenEBS"
+    sortOrder         = 45
+    computeVersion    = "16.04"
+    description       = "This will provision a single kubernetes master in upcloud with weave and openebs"
+    type              = compute-server-type.upcloud-kube-master
+    serverCount       = 6
+    memoryRequirement = 2 * 1024 * 1024 * 1024
+    hasAutoScale      = true
+    enabled           = false
+    creatable         = false
+    groupType         = compute-server-group-type.kubernetes-cluster
+    computeServers    = [
+        {code = "kubernetes-upcloud-ha-master-ubuntu-16.04-set"},
+        {code = "kubernetes-upcloud-ha-add-master-ubuntu-16.04-set"},
+        {code = "kubernetes-worker-upcloud-ha-ubuntu-16.04-set"}
+    ]
+    provisionType     = "upcloud"
+    optionTypes       = [
+        {code = "kubernetes.master.podCidr"},
+        {code = "kubernetes.master.clusterHostname"},
+        {code = "kubernetes.master.loadBalancerId"}
+    ]
+}
+
+//Kubernetes 1.17
+		//kubernetes master - weave - openebs
+resource "workload-type" "kubernetes-upcloud-ubuntu-18_04" {
+    code             = "kubernetes-upcloud-ubuntu-18.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes 1.17 Cluster on Ubuntu 18.04"
+    containerVersion = "18.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 18.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-install-curl-1_17_3"},
+        {code = "kube-kubeadm-init"},
+        {code = "kube-kubeadm-copy-config"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-install-openebs-1-10-0-curl"},
+        {code = "kube-kubeadm-create-service-account"},
+        {code = "kube-kubeadm-check-pods"},
+        {code = "kube-kubeadm-install-weave"},
+        {code = "kube-kubeadm-install-openebs-1-10-0"},
+        {code = "kube-install-fluentbit"}
+    ]
+    templates = [
+        {code = "kube-logging-fluentbit-service-spec"},
+        {code = "kube-logging-fluentbit-role-spec"},
+        {code = "kube-logging-fluentbit-role-binding-spec"},
+        {code = "kube-logging-fluentbit-config-spec"},
+        {code = "kube-logging-fluentbit-daemon-spec-1-16"}
+    ]
+}
+
+resource "workload-type" "kubernetes-upcloud-worker-ubuntu-18_04" {
+    code             = "kubernetes-upcloud-worker-ubuntu-18.04"
+    shortName        = "kubernetes-worker-ubuntu"
+    name             = "Kubernetes Worker 1.17 on Ubuntu 18.04"
+    containerVersion = "18.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 18.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-install-curl-1_17_3"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-worker-join"}
+    ]
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ubuntu-18_04-set" {
+    code                    = "kubernetes-upcloud-ubuntu-18.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ubuntu-18_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 0
+    dynamicCount            = false
+    nodeCount               = 1
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-worker-upcloud-ubuntu-18_04-set" {
+    code                    = "kubernetes-worker-upcloud-ubuntu-18.04-set"
+    name                    = "kubernetes worker"
+    workloadType            = workload-type.kubernetes-upcloud-worker-ubuntu-18_04
+    computeServerType       = compute-server-type.upcloud-kube-worker
+    category                = "ubuntu"
+    priorityOrder           = 1
+    dynamicCount            = true
+    nodeCount               = 3
+    nameSuffix              = "-worker"
+    nodeType                = "worker"
+    canAddNodes             = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-layout" "kubernetes-upcloud-ubuntu-18_04-single" {
+    code              = "kubernetes-upcloud-ubuntu-18.04-single"
+    name              = "Kubernetes 1.17 Cluster on Ubuntu 18.04, Weave, OpenEBS"
+    sortOrder         = 20
+    computeVersion    = "18.04"
+    description       = "This will provision a single kubernetes master in upcloud with weave and openebs"
+    type              = compute-server-type.upcloud-kube-master
+    serverCount       = 4
+    memoryRequirement = 1024 * 1024 * 1024
+    hasAutoScale      = true
+    groupType         = compute-server-group-type.kubernetes-cluster
+    computeServers    = [
+        {code = "kubernetes-upcloud-ubuntu-18.04-set"},
+        {code = "kubernetes-worker-upcloud-ubuntu-18.04-set"}
+    ]
+    provisionType     = "upcloud"
+    optionTypes       = [{code = "kubernetes.master.podCidr"}]
+}
+
+//kubernetes ha cluster - weave - openebs
+resource "workload-type" "kubernetes-upcloud-ha-master-ubuntu-18_04" {
+    code             = "kubernetes-upcloud-ha-master-ubuntu-18.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes HA Master 1.17 on Ubuntu 18.04"
+    containerVersion = "18.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 18.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-cluster-master-prep"},
+        {code = "kube-kubeadm-cluster-shared-key"},
+        {code = "kube-kubeadm-install-curl-1_17_3"},
+        {code = "kube-kubeadm-cluster-master-init-1_17_3"},
+        {code = "kube-kubeadm-copy-config"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-install-openebs-1-10-0-curl"},
+        {code = "kube-kubeadm-create-service-account"},
+        {code = "kube-kubeadm-check-pods"},
+        {code = "kube-kubeadm-cluster-install-weave"},
+        {code = "kube-kubeadm-cluster-install-openebs-1-10-0"},
+        {code = "kube-install-fluentbit"}
+    ]
+    templates = [
+        {code = "kube-kubeadm-cluster-master-config-1_17_3"},
+        {code = "kube-logging-fluentbit-service-spec"},
+        {code = "kube-logging-fluentbit-role-spec"},
+        {code = "kube-logging-fluentbit-role-binding-spec"},
+        {code = "kube-logging-fluentbit-config-spec"},
+        {code = "kube-logging-fluentbit-daemon-spec-1-16"}
+    ]
+}
+
+resource "workload-type" "kubernetes-upcloud-ha-add-master-ubuntu-18_04" {
+    code             = "kubernetes-upcloud-ha-add-master-ubuntu-18.04"
+    shortName        = "kubernetes-ubuntu"
+    name             = "Kubernetes HA Add Master 1.17 on Ubuntu 18.04"
+    containerVersion = "18.04"
+    repositoryImage  = null
+    imageCode        = "morpheus ubuntu 18.04"
+    entryPoint       = null
+    mountLogs        = "/var/log"
+    statTypeCode     = "server"
+    logTypeCode      = "ubuntu"
+    showServerLogs   = true
+    category         = "ubuntu"
+    cloneType        = "ubuntu"
+    priorityOrder    = 0
+    serverType       = "vm"
+    providerType     = "upcloud"
+    checkTypeCode    = "vmCheck"
+    virtualImage     = virtual-image.upcloud-image-morpheus-ubuntu-20.04
+    containerPorts   = [{code = "ubuntu.22"}]
+    provisionType    = "upcloud"
+    scripts = [
+        {code = "kube-kubeadm-cluster-master-prep"},
+        {code = "kube-kubeadm-cluster-shared-key"},
+        {code = "kube-kubeadm-install-curl-1_17_3"},
+        {code = "kube-kubeadm-cluster-add-master-certs"},
+        {code = "kube-kubeadm-iscsi-install-curl"},
+        {code = "kube-kubeadm-cluster-add-master-init-1_17_3"},
+        {code = "kube-kubeadm-copy-config"}
+    ]
+    templates = [{code = "kube-kubeadm-cluster-add-master-config-1_17_3"}]
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ha-master-ubuntu-18_04-set" {
+    code                    = "kubernetes-upcloud-ha-master-ubuntu-18.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ha-master-ubuntu-18_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 0
+    dynamicCount            = false
+    nodeCount               = 1
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    forceNameIndex          = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-upcloud-ha-add-master-ubuntu-18_04-set" {
+    code                    = "kubernetes-upcloud-ha-add-master-ubuntu-18.04-set"
+    name                    = "kubernetes master"
+    workloadType            = workload-type.kubernetes-upcloud-ha-add-master-ubuntu-18_04
+    computeServerType       = compute-server-type.upcloud-kube-master
+    category                = "ubuntu"
+    priorityOrder           = 1
+    dynamicCount            = false
+    nodeCount               = 2
+    nameSuffix              = "-master"
+    nodeType                = "master"
+    forceNameIndex          = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-set" "kubernetes-worker-upcloud-ha-ubuntu-18_04-set" {
+    code                    = "kubernetes-worker-upcloud-ha-ubuntu-18.04-set"
+    name                    = "kubernetes worker"
+    workloadType            = workload-type.kubernetes-upcloud-worker-ubuntu-18_04
+    computeServerType       = compute-server-type.upcloud-kube-worker
+    category                = "ubuntu"
+    priorityOrder           = 2
+    dynamicCount            = true
+    nodeCount               = 3
+    nameSuffix              = "-worker"
+    nodeType                = "worker"
+    forceNameIndex          = true
+    canAddNodes             = true
+    installContainerRuntime = true
+    installStorageRuntime   = true
+}
+
+resource "compute-type-layout" "kubernetes-upcloud-ubuntu-18_04-cluster-weave-openebs" {
+    code              = "kubernetes-upcloud-ubuntu-18.04-cluster-weave-openebs"
+    name              = "Kubernetes 1.17 HA Cluster on Ubuntu 18.04, Weave, OpenEBS"
+    sortOrder         = 25
+    computeVersion    = "18.04"
+    description       = "This will provision a single kubernetes master in upcloud with weave and openebs"
+    type              = compute-server-type.upcloud-kube-master
+    serverCount       = 6
+    memoryRequirement = 2 * 1024 * 1024 * 1024
+    hasAutoScale      = true
+    groupType         = compute-server-group-type.kubernetes-cluster
+    computeServers    = [
+        {code = "kubernetes-upcloud-ha-master-ubuntu-18.04-set"},
+        {code = "kubernetes-upcloud-ha-add-master-ubuntu-18.04-set"},
+        {code = "kubernetes-worker-upcloud-ha-ubuntu-18.04-set"}
+    ]
+    provisionType     = "upcloud"
+    optionTypes       = [
+        {code = "kubernetes.master.podCidr"},
+        {code = "kubernetes.master.clusterHostname"},
+        {code = "kubernetes.master.loadBalancerId"}
+    ]
+}

--- a/src/main/resources/scribe/upcloud-instance-types.scribe
+++ b/src/main/resources/scribe/upcloud-instance-types.scribe
@@ -40,9 +40,9 @@ resource "workload-type" "upcloud-1_0" {
   mountPoint       = "/data"
   provisionType    = "upcloud"
   commEnabled      = true
-  commType         = 'SSH'
+  commType         = "SSH"
   commPort         = 22
-  backupType       = 'upCloudSnapshot'
+  backupType       = "upCloudSnapshot"
   actions = ["generic-remove-node"]
 }
 
@@ -74,7 +74,7 @@ resource "instance-type" "upcloud" {
   environmentPrefix       = "UPCLOUD"
   provisionSelectType     = "zone"
   provisionType           = "upcloud"
-  backupType              = 'upCloudSnapshot'
+  backupType              = "upCloudSnapshot"
   pluginIconPath          = "upcloud-light.svg"
   pluginIconDarkPath      = "upcloud-dark.svg"
   pluginIconHidpiPath     = "upcloud-light0.svg"

--- a/src/main/resources/scribe/upcloud-instance-types.scribe
+++ b/src/main/resources/scribe/upcloud-instance-types.scribe
@@ -1,9 +1,9 @@
-resource "option-type" "containerType-upcloud-template" {
-  code         = "containerType.upcloud.template"
+resource "option-type" "containerType-upcloud-image" {
+  code         = "containerType.upcloud.imageId"
   type         = "select"
-  name         = "template"
+  name         = "imageType"
   category     = "containerType.upcloud"
-  fieldName    = "template"
+  fieldName    = "imageId"
   optionSource = "upcloudImage"
   optionSourceType = "upcloud"
   fieldCode    = "gomorpheus.optiontype.Image"
@@ -18,7 +18,7 @@ resource "option-type" "containerType-upcloud-template" {
   helpBlock    = ""
   defaultValue = null
   custom       = false
-  displayOrder = 8
+  displayOrder = 3
   fieldClass   = null
   visibleOnCode = null
   description  = "Choose from a list of Virtual Images that might want to be provisioned."
@@ -39,6 +39,10 @@ resource "workload-type" "upcloud-1_0" {
   serverType       = "vm"
   mountPoint       = "/data"
   provisionType    = "upcloud"
+  commEnabled      = true
+  commType         = 'SSH'
+  commPort         = 22
+  backupType       = 'upCloudSnapshot'
   actions = ["generic-remove-node"]
 }
 
@@ -70,6 +74,7 @@ resource "instance-type" "upcloud" {
   environmentPrefix       = "UPCLOUD"
   provisionSelectType     = "zone"
   provisionType           = "upcloud"
+  backupType              = 'upCloudSnapshot'
   pluginIconPath          = "upcloud-light.svg"
   pluginIconDarkPath      = "upcloud-dark.svg"
   pluginIconHidpiPath     = "upcloud-light0.svg"

--- a/src/main/resources/scribe/upcloud-instance-types.scribe
+++ b/src/main/resources/scribe/upcloud-instance-types.scribe
@@ -1,8 +1,8 @@
-resource "option-type" "containerType-upcloud-image" {
-  code         = "containerType.upcloud.imageId"
+resource "option-type" "workloadType-upcloud-image" {
+  code         = "workloadType.upcloud.imageId"
   type         = "select"
   name         = "imageType"
-  category     = "containerType.upcloud"
+  category     = "workloadType.upcloud"
   fieldName    = "imageId"
   optionSource = "upcloudImage"
   optionSourceType = "upcloud"
@@ -20,8 +20,106 @@ resource "option-type" "containerType-upcloud-image" {
   custom       = false
   displayOrder = 3
   fieldClass   = null
-  visibleOnCode = null
-  description  = "Choose from a list of Virtual Images that might want to be provisioned."
+}
+
+resource "virtual-image" "upcloud-image-morpheus-ubuntu-14_04" {
+    code                = "upcloud.image.morpheus.ubuntu.14.04"
+    category            = "upcloud.image.morpheus"
+    sshUsername         = "root"
+    sshPassword         = null
+    name                = "morpheus ubuntu 14.04"
+    imageType           = "qcow2"
+    systemImage         = true
+    installAgent        = true
+    computeServerImage  = true
+    isCloudInit         = false
+    externalId          = "01000000-0000-4000-8000-000030040200"
+    osType              = {code = "ubuntu.14.04.64"}
+}
+
+resource "virtual-image" "upcloud-image-morpheus-ubuntu-18_04" {
+    code                = "upcloud.image.morpheus.ubuntu.18.04"
+    category            = "upcloud.image.morpheus"
+    sshUsername         = "root"
+    sshPassword         = null
+    name                = "morpheus ubuntu 18.04"
+    imageType           = "qcow2"
+    systemImage         = true
+    installAgent        = true
+    computeServerImage  = true
+    isCloudInit         = false
+    externalId          = "01000000-0000-4000-8000-000030080200"
+    osType              = {code = "ubuntu.18.04.64"}
+}
+
+resource "virtual-image" "upcloud-image-morpheus-ubuntu-20_04" {
+    code                = "upcloud.image.morpheus.ubuntu.20.04"
+    category            = "upcloud.image.morpheus"
+    sshUsername         = "root"
+    sshPassword         = null
+    name                = "morpheus ubuntu 20.04"
+    imageType           = "qcow2"
+    systemImage         = true
+    installAgent        = true
+    computeServerImage  = true
+    isCloudInit         = false
+    externalId          = "01000000-0000-4000-8000-000030200200"
+    osType              = {code = "ubuntu.20.04.64"}
+}
+
+resource "virtual-image" "upcloud-image-morpheus-centos-7_3" {
+    code                = "upcloud.image.morpheus.centos.7.3"
+    category            = "upcloud.image.morpheus"
+    sshUsername         = "root"
+    sshPassword         = null
+    name                = "Morpheus CentOS 7.3"
+    imageType           = "qcow2"
+    systemImage         = true
+    installAgent        = true
+    computeServerImage  = true
+    isCloudInit         = false
+    externalId          = "01000000-0000-4000-8000-000050010300"
+    osType              = {code = "cent.7.64"}
+}
+
+resource "virtual-image" "upcloud-image-morpheus-centos-7_5" {
+    code                = "upcloud.image.morpheus.centos.7.5"
+    category            = "upcloud.image.morpheus"
+    sshUsername         = "root"
+    sshPassword         = null
+    name                = "Morpheus CentOS 7.5"
+    imageType           = "qcow2"
+    systemImage         = true
+    installAgent        = true
+    computeServerImage  = true
+    isCloudInit         = false
+    externalId          = "01000000-0000-4000-8000-000050010300"
+    osType              = {code = "cent.7.64"}
+}
+
+resource "instance-type" "upcloud" {
+  code                    = "upcloud"
+  name                    = "UpCloud"
+  category                = "cloud"
+  active                  = true
+  enabled                 = true
+  viewSet                 = "upcloud"
+  stackTier               = 30
+  hasConfig               = false
+  hasSettings             = false
+  hasDeployment           = false
+  versions = ["1.0"]
+  hasAutoScale            = true
+  provisionService        = "upCloudContainerService"
+  provisionTypeDefault    = true
+  environmentPrefix       = "UPCLOUD"
+  provisionSelectType     = "zone"
+  provisionType           = "upcloud"
+  backupType              = "upCloudSnapshot"
+  optionTypes             = [
+    option-type.workloadType-upcloud-template,
+    "instanceType.exposePorts"
+  ]
 }
 
 resource "workload-type" "upcloud-1_0" {
@@ -43,7 +141,7 @@ resource "workload-type" "upcloud-1_0" {
   commType         = "SSH"
   commPort         = 22
   backupType       = "upCloudSnapshot"
-  actions = ["generic-remove-node"]
+  actions = [{code = "generic-remove-node"}]
 }
 
 resource "workload-type-set" "upcloud-1_0-set" {
@@ -54,50 +152,19 @@ resource "workload-type-set" "upcloud-1_0-set" {
   containerCount = 1
 }
 
-resource "instance-type" "upcloud" {
-  code                    = "upcloud"
-  name                    = "UpCloud"
-  category                = "cloud"
-  active                  = true
-  enabled                 = true
-  viewSet                 = "upcloud"
-  stackTier               = 30
-  hasConfig               = false
-  hasSettings             = false
-  hasDeployment           = false
-  deploymentService       = "defaultDeployService"
-  versions = ["1.0"]
-  hasAutoScale            = true
-  description             = "Spin up any VM Image on your upcloud based infrastructure."
-  provisionService        = "upCloudContainerService"
-  provisionTypeDefault    = true
-  environmentPrefix       = "UPCLOUD"
-  provisionSelectType     = "zone"
-  provisionType           = "upcloud"
-  backupType              = "upCloudSnapshot"
-  pluginIconPath          = "upcloud-light.svg"
-  pluginIconDarkPath      = "upcloud-dark.svg"
-  pluginIconHidpiPath     = "upcloud-light0.svg"
-  pluginIconDarkHidpiPath = "upcloud-dark.svg"
-  optionTypes             = [
-    option-type.containerType-upcloud-template,
-    "instanceType.exposePorts"
-  ]
-}
-
 resource "instance-type-layout" "upcloud-1_0-single" {
   code            = "upcloud-1.0-single"
   name            = "UpCloud VM"
   sortOrder       = 0
   instanceVersion = "1.0"
   description     = "This will provision a single process with no redundancy"
-  instanceType    = "upcloud"
+  instanceType    = instance-type.upcloud
   serverCount     = 1
   portCount       = 1
   enabled         = true
   creatable       = true
-  containers      = ["upcloud-1.0-set"]
-  actions         = ["generic-add-node"]
+  workloads       = workload-type-set.upcloud-1_0-set
+  actions         = [{code = "generic-add-node"}]
   optionTypes     = []
   provisionType   = "upcloud"
 }
@@ -106,6 +173,6 @@ resource "scale-action" "upcloud-1_0-single" {
   code       = "upcloud-1.0-single"
   scaleType  = "action"
   layout     = "upcloud-1.0-single"
-  upAction   = "generic-add-node"
-  downAction = "generic-remove-node"
+  upAction   = {code = "generic-add-node"}
+  downAction = {code = "generic-remove-node"}
 }

--- a/src/main/resources/scribe/upcloud-instance-types.scribe
+++ b/src/main/resources/scribe/upcloud-instance-types.scribe
@@ -1,0 +1,106 @@
+resource "option-type" "containerType-upcloud-template" {
+  code         = "containerType.upcloud.template"
+  type         = "select"
+  name         = "template"
+  category     = "containerType.upcloud"
+  fieldName    = "template"
+  optionSource = "upcloudImage"
+  optionSourceType = "upcloud"
+  fieldCode    = "gomorpheus.optiontype.Image"
+  fieldLabel   = "Image"
+  fieldContext = "config"
+  fieldGroup   = "Options"
+  required     = false
+  enabled      = true
+  editable     = false
+  global       = false
+  placeHolder  = null
+  helpBlock    = ""
+  defaultValue = null
+  custom       = false
+  displayOrder = 8
+  fieldClass   = null
+  visibleOnCode = null
+  description  = "Choose from a list of Virtual Images that might want to be provisioned."
+}
+
+resource "workload-type" "upcloud-1_0" {
+  code             = "upcloud-1.0"
+  shortName        = "upcloud"
+  name             = "UpCloud VM"
+  ports = []
+  containerVersion = "1.0"
+  repositoryImage  = ""
+  entryPoint       = ""
+  category         = "upcloud"
+  statTypeCode     = "vm"
+  logTypeCode      = "upcloud"
+  checkTypeCode    = "containerCheck"
+  serverType       = "vm"
+  mountPoint       = "/data"
+  provisionType    = "upcloud"
+  actions = ["generic-remove-node"]
+}
+
+resource "workload-type-set" "upcloud-1_0-set" {
+  code           = "upcloud-1.0-set"
+  workloadType   = workload-type.upcloud-1_0
+  priorityOrder  = 0
+  dynamicCount   = true
+  containerCount = 1
+}
+
+resource "instance-type" "upcloud" {
+  code                    = "upcloud"
+  name                    = "UpCloud"
+  category                = "cloud"
+  active                  = true
+  enabled                 = true
+  viewSet                 = "upcloud"
+  stackTier               = 30
+  hasConfig               = false
+  hasSettings             = false
+  hasDeployment           = false
+  deploymentService       = "defaultDeployService"
+  versions = ["1.0"]
+  hasAutoScale            = true
+  description             = "Spin up any VM Image on your upcloud based infrastructure."
+  provisionService        = "upCloudContainerService"
+  provisionTypeDefault    = true
+  environmentPrefix       = "UPCLOUD"
+  provisionSelectType     = "zone"
+  provisionType           = "upcloud"
+  pluginIconPath          = "upcloud-light.svg"
+  pluginIconDarkPath      = "upcloud-dark.svg"
+  pluginIconHidpiPath     = "upcloud-light0.svg"
+  pluginIconDarkHidpiPath = "upcloud-dark.svg"
+  optionTypes             = [
+    option-type.containerType-upcloud-template,
+    "instanceType.exposePorts"
+  ]
+}
+
+resource "instance-type-layout" "upcloud-1_0-single" {
+  code            = "upcloud-1.0-single"
+  name            = "UpCloud VM"
+  sortOrder       = 0
+  instanceVersion = "1.0"
+  description     = "This will provision a single process with no redundancy"
+  instanceType    = "upcloud"
+  serverCount     = 1
+  portCount       = 1
+  enabled         = true
+  creatable       = true
+  containers      = ["upcloud-1.0-set"]
+  actions         = ["generic-add-node"]
+  optionTypes     = []
+  provisionType   = "upcloud"
+}
+
+resource "scale-action" "upcloud-1_0-single" {
+  code       = "upcloud-1.0-single"
+  scaleType  = "action"
+  layout     = "upcloud-1.0-single"
+  upAction   = "generic-add-node"
+  downAction = "generic-remove-node"
+}


### PR DESCRIPTION
Tested and working:
- backup create from instance provision
- backup create from instance detail page
- execute backup
- restore to current and new (with test files)
- delete snapshot
- backups and restores with additional data disks

Added:
- ported `ComputeServerTypeUpcloudSeed`, `ProvisionTypeUpcloud`, `UpcloudComputeTypeSeed`, `UpCloudSeed`, `UpcloudStorageVolumeTypeSeed`, and `UpCloudZoneTypeSeed`